### PR TITLE
feat: remove passwords from kde to prevent login when idle

### DIFF
--- a/debian-kde/Dockerfile
+++ b/debian-kde/Dockerfile
@@ -20,7 +20,7 @@ RUN chmod 777 /home/stardust
 RUN chmod 777 /app
 RUN echo "stardust ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 RUN usermod -aG sudo stardust
-RUN echo 'root:' | chpasswd -e
+#RUN echo 'root:' | chpasswd -e
 RUN echo 'stardust:' | chpasswd -e
 USER stardust
 RUN mkdir -p /home/stardust/.vnc

--- a/debian-kde/Dockerfile
+++ b/debian-kde/Dockerfile
@@ -20,6 +20,8 @@ RUN chmod 777 /home/stardust
 RUN chmod 777 /app
 RUN echo "stardust ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 RUN usermod -aG sudo stardust
+RUN echo 'root:' | chpasswd -e
+RUN echo 'stardust:' | chpasswd -e
 USER stardust
 RUN mkdir -p /home/stardust/.vnc
 RUN touch /home/stardust/.Xresources


### PR DESCRIPTION
**Fixes**:
* Fixes a login screen prompt from appearing when the user has been idle for too long by removing the passwords from the `stardust` user.